### PR TITLE
SCRUM-87-feat(ProjetoPorUsuario):add endpoint with optional user filter, Swagger docs, and service tests

### DIFF
--- a/stratify/src/main/java/com/quantum/stratify/entities/Projeto.java
+++ b/stratify/src/main/java/com/quantum/stratify/entities/Projeto.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -33,4 +34,7 @@ public class Projeto {
 
     @OneToMany(mappedBy = "projeto")
     private List<FatoEficienciaUserStory> fatoEficienciaUserStories;
+
+    @ManyToMany(mappedBy = "projetos")
+    List<Usuario> usuarios;
 }

--- a/stratify/src/main/java/com/quantum/stratify/entities/UserStory.java
+++ b/stratify/src/main/java/com/quantum/stratify/entities/UserStory.java
@@ -63,7 +63,6 @@ public class UserStory {
     @JoinColumn(name = "id_projeto", nullable = false)
     private Projeto projeto;
 
-
     @ManyToMany
     @JoinTable(name = "relacionamento_tag_user_story",
         joinColumns = @JoinColumn(name = "id_user_story"),

--- a/stratify/src/main/java/com/quantum/stratify/entities/Usuario.java
+++ b/stratify/src/main/java/com/quantum/stratify/entities/Usuario.java
@@ -10,6 +10,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -39,4 +42,10 @@ public class Usuario {
 
     @OneToMany(mappedBy = "usuario")
     private List<FatoEficienciaUserStory> eficienciaUserStories;
+
+    @ManyToMany
+    @JoinTable(name = "relacionamento_projeto_usuario",
+    joinColumns = @JoinColumn(name = "id_usuario"),
+    inverseJoinColumns = @JoinColumn(name = "id_projeto"))
+    private List<Projeto> projetos;
 }

--- a/stratify/src/main/java/com/quantum/stratify/repositories/ProjetoRepository.java
+++ b/stratify/src/main/java/com/quantum/stratify/repositories/ProjetoRepository.java
@@ -1,11 +1,25 @@
 package com.quantum.stratify.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.quantum.stratify.entities.Projeto;
+import com.quantum.stratify.web.dtos.ProjetoDTO;
 
 @Repository
 public interface ProjetoRepository extends JpaRepository<Projeto, Long>{
+
+    @Query("""
+        SELECT new com.quantum.stratify.web.dtos.ProjetoDTO(p.id, p.nome)
+        FROM Projeto p
+        LEFT JOIN p.usuarios u
+        WHERE (:idUsuario IS NULL OR u.id = :idUsuario)
+        GROUP BY p.id, p.nome
+        """)
+    List<ProjetoDTO> findProjetoByUsuarioId(@Param("idUsuario") Long idUsuario);
 
 }

--- a/stratify/src/main/java/com/quantum/stratify/services/ProjetoService.java
+++ b/stratify/src/main/java/com/quantum/stratify/services/ProjetoService.java
@@ -27,6 +27,10 @@ public class ProjetoService {
         }).collect(Collectors.toList());
     }
 
+    public List<ProjetoDTO> buscarProjetosPorUsuarios(Long idUsuario){
+        return projetoRepository.findProjetoByUsuarioId(idUsuario);
+    }
+
 }
 
 

--- a/stratify/src/main/java/com/quantum/stratify/web/controllers/ProjetoController.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/controllers/ProjetoController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.quantum.stratify.services.ProjetoService;
@@ -34,4 +35,14 @@ public class ProjetoController {
     public List<ProjetoDTO> getAllProjetos() {
         return projetoService.getAll();
     }
+
+    @GetMapping("/porUsuario")
+    @Operation(summary = "Get project summaries", description = "Returns a list of projects filtered by optional user ID")
+    @ApiResponses( value = {
+        @ApiResponse(responseCode = "200", description = "List of project summaries returned succesfully")
+    })
+    public List<ProjetoDTO> getProjetosUsuario(
+        @RequestParam(name = "idUsuario", required = false) Long idUsuario) {
+            return projetoService.buscarProjetosPorUsuarios(idUsuario);
+        }
 }

--- a/stratify/src/test/java/com/quantum/stratify/services/ProjetoServiceTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/services/ProjetoServiceTest.java
@@ -1,11 +1,7 @@
 package com.quantum.stratify.services;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -85,4 +81,44 @@ public class ProjetoServiceTest {
         assertTrue(resultados.isEmpty());
         verify(projetoRepository, times(1)).findAll();
     }
+
+    @Test
+    void buscarProjetosPorUsuarios_DeveRetornarProjetosAssociadosAoUsuario() {
+    // Arrange
+    Long usuarioId = 1L;
+    List<ProjetoDTO> projetosMock = List.of(
+        new ProjetoDTO(10L, "Projeto A"),
+        new ProjetoDTO(11L, "Projeto B")
+    );
+
+    when(projetoRepository.findProjetoByUsuarioId(usuarioId)).thenReturn(projetosMock);
+
+    // Act
+    List<ProjetoDTO> resultado = projetoService.buscarProjetosPorUsuarios(usuarioId);
+
+    // Assert
+    assertEquals(2, resultado.size());
+    assertEquals("Projeto A", resultado.get(0).nome());
+    verify(projetoRepository, times(1)).findProjetoByUsuarioId(usuarioId);
+    }
+
+    @Test
+    void buscarProjetosPorUsuarios_SemUsuario_DeveRetornarTodosProjetos() {
+        // Arrange
+        List<ProjetoDTO> projetosMock = List.of(
+            new ProjetoDTO(20L, "Projeto X"),
+            new ProjetoDTO(21L, "Projeto Y")
+        );
+
+        when(projetoRepository.findProjetoByUsuarioId(null)).thenReturn(projetosMock);
+
+        // Act
+        List<ProjetoDTO> resultado = projetoService.buscarProjetosPorUsuarios(null);
+
+        // Assert
+        assertEquals(2, resultado.size());
+        assertEquals("Projeto X", resultado.get(0).nome());
+        verify(projetoRepository, times(1)).findProjetoByUsuarioId(null);
+    }
+
 }


### PR DESCRIPTION
- Added GET /projetos/resumo endpoint with optional query param idUsuario
- Documented the endpoint using @Operation and @ApiResponses (Swagger)
- Added unit tests in ProjetoServiceTest:
  - Filtering projects by user ID
  - Retrieving all projects when no user ID is provided
- Updated JPQL in ProjetoRepository to use user ID in query
- Used ProjetoDTO to return summarized project data (id and name)
