### PR TITLE
SCRUM-56-feat(AtivarDesativarUsuarios): add activate/deactivate endpo…

### DIFF
--- a/stratify/src/main/java/com/quantum/stratify/entities/Usuario.java
+++ b/stratify/src/main/java/com/quantum/stratify/entities/Usuario.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.quantum.stratify.enums.Role;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -36,6 +37,9 @@ public class Usuario {
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @Column(name = "is_enable", nullable = false)
+    private Boolean isEnable;
 
     @OneToMany(mappedBy = "usuario")
     private List<FatoEficienciaUserStory> eficienciaUserStories;

--- a/stratify/src/main/java/com/quantum/stratify/repositories/UsuarioRepository.java
+++ b/stratify/src/main/java/com/quantum/stratify/repositories/UsuarioRepository.java
@@ -1,0 +1,11 @@
+package com.quantum.stratify.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.quantum.stratify.entities.Usuario;
+
+@Repository
+public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+
+}

--- a/stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java
+++ b/stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java
@@ -1,0 +1,31 @@
+package com.quantum.stratify.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.quantum.stratify.entities.Usuario;
+import com.quantum.stratify.repositories.UsuarioRepository;
+
+@Service
+public class UsuarioService {
+    
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    public void ativarUsuario(Long id) {
+        Usuario usuario = usuarioRepository.findById(id)
+            .orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado"));
+        usuario.setIsEnable(true);
+        usuarioRepository.save(usuario);
+    }
+
+    public void desativarUsuario(Long id) {
+        Usuario usuario = usuarioRepository.findById(id)
+            .orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado"));
+        usuario.setIsEnable(false);
+        usuarioRepository.save(usuario);
+    }
+
+}

--- a/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
@@ -1,0 +1,47 @@
+package com.quantum.stratify.web.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.quantum.stratify.services.UsuarioService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@RestController
+@CrossOrigin("*")
+@RequestMapping("/usuario")
+public class UsuarioController {
+
+    @Autowired
+    public UsuarioService usuarioService;
+
+    @PutMapping("/{id}/ativar")
+    @Operation(summary = "Ativar usuário", description = "Ativa um usuário com base no ID")
+    @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "Usuário ativado com sucesso"),
+    @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
+    public ResponseEntity<Void> ativarUsuario(@PathVariable Long id) {
+    usuarioService.ativarUsuario(id);
+    return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{id}/desativar")
+    @Operation(summary = "Desativar usuário", description = "Desativa um usuário com base no ID")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Usuário desativado com sucesso"),
+        @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
+    public ResponseEntity<Void> desativarUsuario(@PathVariable Long id) {
+    usuarioService.desativarUsuario(id);
+    return ResponseEntity.noContent().build();
+    }
+    
+}

--- a/stratify/src/test/java/com/quantum/stratify/services/UsuarioServiceTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/services/UsuarioServiceTest.java
@@ -1,0 +1,90 @@
+package com.quantum.stratify.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.quantum.stratify.entities.Usuario;
+import com.quantum.stratify.repositories.UsuarioRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class UsuarioServiceTest {
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @InjectMocks
+    private UsuarioService usuarioService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void shouldActivateUser() {
+        // Arrange
+        Usuario usuario = new Usuario();
+        usuario.setId(1L);
+        usuario.setIsEnable(false);
+
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuario));
+
+        // Act
+        usuarioService.ativarUsuario(1L);
+
+        // Assert
+        assertTrue(usuario.getIsEnable());
+        verify(usuarioRepository).save(usuario);
+    }
+
+    @Test
+    void shouldDisableUser() {
+        // Arrange
+        Usuario usuario = new Usuario();
+        usuario.setId(2L);
+        usuario.setIsEnable(true);
+
+        when(usuarioRepository.findById(2L)).thenReturn(Optional.of(usuario));
+
+        // Act
+        usuarioService.desativarUsuario(2L);
+
+        // Assert
+        assertFalse(usuario.getIsEnable());
+        verify(usuarioRepository).save(usuario);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUserNotFoundOnActivate() {
+        when(usuarioRepository.findById(99L)).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            usuarioService.ativarUsuario(99L);
+        });
+
+        assertEquals("Usuário não encontrado", exception.getReason());
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUserNotFoundOnDisable() {
+        when(usuarioRepository.findById(100L)).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            usuarioService.desativarUsuario(100L);
+        });
+
+        assertEquals("Usuário não encontrado", exception.getReason());
+        verify(usuarioRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
- Implemented PUT /usuario/{id}/ativar and /usuario/{id}/desativar
- Added logic to update 'isEnable' field in UsuarioService
- Created UsuarioRepository to persist user updates
- Included Swagger annotations (@Operation, @ApiResponse) for endpoint docs
- Added unit tests for activate and deactivate logic in UsuarioServiceTest
- Fixed Enum mapping issue in Role (requires USER or ADMIN in DB)
- Confirmed behavior via Postman and DB validation