### PR TITLE
SCRUM-84-feat(UsuarioPorProjetoEGestor): implement endpoint to filter…

### DIFF
--- a/stratify/src/main/java/com/quantum/stratify/entities/Usuario.java
+++ b/stratify/src/main/java/com/quantum/stratify/entities/Usuario.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -43,6 +44,14 @@ public class Usuario {
 
     @Column(name = "is_enable", nullable = false)
     private Boolean isEnable;
+
+    @ManyToOne
+    @JoinColumn(name="id_gestor")
+    private Usuario gestor;
+
+    @OneToMany(mappedBy = "gestor")
+    private List<Usuario> subordinado;
+
 
     @OneToMany(mappedBy = "usuario")
     private List<FatoEficienciaUserStory> eficienciaUserStories;

--- a/stratify/src/main/java/com/quantum/stratify/repositories/UsuarioRepository.java
+++ b/stratify/src/main/java/com/quantum/stratify/repositories/UsuarioRepository.java
@@ -1,11 +1,27 @@
 package com.quantum.stratify.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.quantum.stratify.entities.Usuario;
+import com.quantum.stratify.web.dtos.UsuarioDTO;
 
 @Repository
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
 
+        @Query("""
+            SELECT DISTINCT new com.quantum.stratify.web.dtos.UsuarioDTO(u.id, u.nome)
+            FROM Usuario u
+            LEFT JOIN u.projetos p
+            WHERE (:idProjeto IS NULL OR p.id = :idProjeto)
+            AND (:idGestor IS NULL OR u.gestor.id = :idGestor)
+    """)
+    List<UsuarioDTO> findUsuarioByProjetoAndGestor(
+        @Param("idProjeto") Long idProjeto,
+        @Param("idGestor") Long idGestor
+    );
 }

--- a/stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java
+++ b/stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java
@@ -1,5 +1,7 @@
 package com.quantum.stratify.services;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -7,6 +9,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.quantum.stratify.entities.Usuario;
 import com.quantum.stratify.repositories.UsuarioRepository;
+import com.quantum.stratify.web.dtos.UsuarioDTO;
 
 @Service
 public class UsuarioService {
@@ -26,6 +29,10 @@ public class UsuarioService {
             .orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado"));
         usuario.setIsEnable(false);
         usuarioRepository.save(usuario);
+    }
+
+    public List<UsuarioDTO> buscarUsuariosPorProjetoEGestor(Long idProjeto, Long idGestor){
+        return usuarioRepository.findUsuarioByProjetoAndGestor(idProjeto, idGestor);
     }
 
 }

--- a/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
@@ -1,14 +1,19 @@
 package com.quantum.stratify.web.controllers;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.quantum.stratify.services.UsuarioService;
+import com.quantum.stratify.web.dtos.UsuarioDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -44,4 +49,18 @@ public class UsuarioController {
     return ResponseEntity.noContent().build();
     }
     
+       
+    @GetMapping("filtrarprojetogestor")
+    @Operation(summary = "Buscar usuários por projeto e/ou gestor")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Usuários encontrados com sucesso")
+    })
+    public ResponseEntity<List<UsuarioDTO>> filtrarUsuarios(
+        @RequestParam(required = false) Long idProjeto,
+        @RequestParam(required = false) Long idGestor
+    ) {
+            List<UsuarioDTO> usuarios = usuarioService.buscarUsuariosPorProjetoEGestor(idProjeto, idGestor);
+            return ResponseEntity.ok(usuarios);
+    }
+
 }

--- a/stratify/src/main/java/com/quantum/stratify/web/dtos/UsuarioDTO.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/dtos/UsuarioDTO.java
@@ -1,0 +1,18 @@
+package com.quantum.stratify.web.dtos;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UsuarioDTO {
+    
+    private Long idUsuario;
+    private String nomeUsuario;
+
+    public UsuarioDTO(Long idUsuario, String nomeUsuario) {
+        this.idUsuario = idUsuario;
+        this.nomeUsuario = nomeUsuario;
+    }
+
+}

--- a/stratify/src/test/java/com/quantum/stratify/services/UsuarioServiceTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/services/UsuarioServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.quantum.stratify.entities.Usuario;
 import com.quantum.stratify.repositories.UsuarioRepository;
+import com.quantum.stratify.web.dtos.UsuarioDTO;
 
 @ExtendWith(MockitoExtension.class)
 public class UsuarioServiceTest {
@@ -86,5 +88,72 @@ public class UsuarioServiceTest {
 
         assertEquals("Usuário não encontrado", exception.getReason());
         verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void deveRetornarTodosUsuariosQuandoFiltrosForemNulos() {
+        // Arrange
+        List<UsuarioDTO> usuariosMock = List.of(
+            new UsuarioDTO(1L, "João"),
+            new UsuarioDTO(2L, "Maria")
+        );
+        when(usuarioRepository.findUsuarioByProjetoAndGestor(null, null)).thenReturn(usuariosMock);
+
+        // Act
+        List<UsuarioDTO> resultado = usuarioService.buscarUsuariosPorProjetoEGestor(null, null);
+
+        // Assert
+        assertEquals(2, resultado.size());
+        assertEquals("João", resultado.get(0).getNomeUsuario());
+        verify(usuarioRepository).findUsuarioByProjetoAndGestor(null, null);
+    }
+
+    @Test
+    void deveRetornarUsuariosDoProjetoQuandoSomenteIdProjetoForInformado() {
+        // Arrange
+        Long idProjeto = 10L;
+        List<UsuarioDTO> usuariosMock = List.of(new UsuarioDTO(3L, "Pedro"));
+        when(usuarioRepository.findUsuarioByProjetoAndGestor(idProjeto, null)).thenReturn(usuariosMock);
+
+        // Act
+        List<UsuarioDTO> resultado = usuarioService.buscarUsuariosPorProjetoEGestor(idProjeto, null);
+
+        // Assert
+        assertEquals(1, resultado.size());
+        assertEquals("Pedro", resultado.get(0).getNomeUsuario());
+        verify(usuarioRepository).findUsuarioByProjetoAndGestor(idProjeto, null);
+    }
+
+    @Test
+    void deveRetornarUsuariosDoGestorQuandoSomenteIdGestorForInformado() {
+        // Arrange
+        Long idGestor = 20L;
+        List<UsuarioDTO> usuariosMock = List.of(new UsuarioDTO(4L, "Lucia"));
+        when(usuarioRepository.findUsuarioByProjetoAndGestor(null, idGestor)).thenReturn(usuariosMock);
+
+        // Act
+        List<UsuarioDTO> resultado = usuarioService.buscarUsuariosPorProjetoEGestor(null, idGestor);
+
+        // Assert
+        assertEquals(1, resultado.size());
+        assertEquals("Lucia", resultado.get(0).getNomeUsuario());
+        verify(usuarioRepository).findUsuarioByProjetoAndGestor(null, idGestor);
+    }
+
+    @Test
+    void deveRetornarUsuariosFiltradosPorProjetoEGestorQuandoAmbosInformados() {
+        // Arrange
+        Long idProjeto = 10L;
+        Long idGestor = 20L;
+        List<UsuarioDTO> usuariosMock = List.of(new UsuarioDTO(5L, "Carlos"));
+        when(usuarioRepository.findUsuarioByProjetoAndGestor(idProjeto, idGestor)).thenReturn(usuariosMock);
+
+        // Act
+        List<UsuarioDTO> resultado = usuarioService.buscarUsuariosPorProjetoEGestor(idProjeto, idGestor);
+
+        // Assert
+        assertEquals(1, resultado.size());
+        assertEquals("Carlos", resultado.get(0).getNomeUsuario());
+        verify(usuarioRepository).findUsuarioByProjetoAndGestor(idProjeto, idGestor);
     }
 }


### PR DESCRIPTION
… users by project and/or manager

- Added GET /usuario/filtrarprojetogestor endpoint to return users based on optional filters: project ID and/or manager ID
- Returns only user ID and name (UsuarioDTO)
- Included Swagger documentation for the new endpoint
- Implemented unit tests for UsuarioService covering all filter combinations (project, manager, both, none)
- Successfully tested the endpoint via Postman with multiple scenarios