### PR TITLE
SCRUM-72-feat(AtribuirRole): add endpoints for role update and filtering by project/manager

### DIFF
--- a/stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java
+++ b/stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java
@@ -1,32 +1,32 @@
 package com.quantum.stratify.services;
 
 
-import com.quantum.stratify.entities.Usuario;
-import com.quantum.stratify.enums.Role;
-import com.quantum.stratify.repositories.UsuarioRepository;
-import com.quantum.stratify.web.exceptions.EntityNotFoundException;
-import com.quantum.stratify.web.exceptions.PasswordInvalidException;
-import com.quantum.stratify.web.exceptions.UsernameUniqueViolationException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.transaction.annotation.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.quantum.stratify.entities.Usuario;
+import com.quantum.stratify.enums.Role;
+import com.quantum.stratify.repositories.UsuarioRepository;
 import com.quantum.stratify.web.dtos.AtribuirGestor;
 import com.quantum.stratify.web.dtos.UsuarioDTO;
+import com.quantum.stratify.web.exceptions.EntityNotFoundException;
+import com.quantum.stratify.web.exceptions.PasswordInvalidException;
+import com.quantum.stratify.web.exceptions.UsernameUniqueViolationException;
 
-@RequiredArgsConstructor
 @Service
 public class UsuarioService {
 
-    @Autowired
-    private UsuarioRepository usuarioRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    public UsuarioService(UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder) {
+        this.usuarioRepository = usuarioRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
     private final PasswordEncoder passwordEncoder;
 
@@ -111,6 +111,18 @@ public class UsuarioService {
         }
     public List<UsuarioDTO> buscarUsuariosPorProjetoEGestor(Long idProjeto, Long idGestor){
         return usuarioRepository.findUsuarioByProjetoAndGestor(idProjeto, idGestor);
+    }
+
+    
+    @Transactional
+    public Usuario alterarRole(Long idUsuario, Role novaRole) {
+    Usuario usuario = usuarioRepository.findById(idUsuario)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado"));
+    if (novaRole == null) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Role inválida.");
+    }
+    usuario.setRole(novaRole);
+    return usuarioRepository.save(usuario);
     }
 }
 

--- a/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
@@ -1,21 +1,29 @@
 package com.quantum.stratify.web.controllers;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.quantum.stratify.entities.Usuario;
 import com.quantum.stratify.services.UsuarioService;
+import com.quantum.stratify.web.dtos.AlterarRoleDTO;
 import com.quantum.stratify.web.dtos.AtribuirGestor;
+import com.quantum.stratify.web.dtos.UsuarioDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 
 @RestController
 @CrossOrigin("*")
@@ -58,6 +66,34 @@ public class UsuarioController {
     ) {
     usuarioService.atribuirLideradosAoGestor(dto);
     return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{idUsuario}")
+    @Operation(summary = "Alterar Role de um usuário", description = "Atualiza a role do usuário")
+    @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "Role alterada com sucesso"),
+    @ApiResponse(responseCode = "400", description = "Dados inválidos"),
+    @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
+    public ResponseEntity<UsuarioDTO> alterarRoleUsuario(
+        @PathVariable Long idUsuario,
+        @Valid @RequestBody AlterarRoleDTO dto) {
+
+    Usuario atualizado = usuarioService.alterarRole(idUsuario, dto.getRole());
+    return ResponseEntity.ok(new UsuarioDTO(atualizado.getId(), atualizado.getNome()));
+    }
+
+    @GetMapping("filtrarprojetogestor")
+    @Operation(summary = "Buscar usuários por projeto e/ou gestor")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Usuários encontrados com sucesso")
+    })
+    public ResponseEntity<List<UsuarioDTO>> filtrarUsuarios(
+        @RequestParam(required = false) Long idProjeto,
+        @RequestParam(required = false) Long idGestor
+    ) {
+        List<UsuarioDTO> usuarios = usuarioService.buscarUsuariosPorProjetoEGestor(idProjeto, idGestor);
+        return ResponseEntity.ok(usuarios);
     }
     
 }

--- a/stratify/src/main/java/com/quantum/stratify/web/dtos/AlterarRoleDTO.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/dtos/AlterarRoleDTO.java
@@ -1,0 +1,13 @@
+package com.quantum.stratify.web.dtos;
+import com.quantum.stratify.enums.Role;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AlterarRoleDTO {
+    @NotNull(message = "Role não pode ser nula")
+    private Role role;
+}

--- a/stratify/src/test/java/com/quantum/stratify/services/UsuarioServiceTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/services/UsuarioServiceTest.java
@@ -229,4 +229,5 @@ public class UsuarioServiceTest {
         assertEquals("Carlos", resultado.get(0).getNomeUsuario());
         verify(usuarioRepository).findUsuarioByProjetoAndGestor(idProjeto, idGestor);
     }
+
 }

--- a/stratify/src/test/java/com/quantum/stratify/services/UsuarioServiceTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/services/UsuarioServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.quantum.stratify.entities.Usuario;
+import com.quantum.stratify.enums.Role;
 import com.quantum.stratify.repositories.UsuarioRepository;
 import com.quantum.stratify.web.dtos.AtribuirGestor;
 import com.quantum.stratify.web.dtos.UsuarioDTO;
@@ -230,4 +231,61 @@ public class UsuarioServiceTest {
         verify(usuarioRepository).findUsuarioByProjetoAndGestor(idProjeto, idGestor);
     }
 
+    @Test
+    void shouldUpdateUserRoleToUSER() {
+        shouldUpdateUserRoleSuccessfully(Role.USER);
+    }
+
+    @Test
+    void shouldUpdateUserRoleToADMIN() {
+        shouldUpdateUserRoleSuccessfully(Role.ADMIN);
+    }
+
+    @Test
+    void shouldUpdateUserRoleToOPERADOR() {
+        shouldUpdateUserRoleSuccessfully(Role.OPERADOR);
+    }
+
+    @Test
+    void shouldUpdateUserRoleToGESTOR() {
+        shouldUpdateUserRoleSuccessfully(Role.GESTOR);
+    }
+
+    private void shouldUpdateUserRoleSuccessfully(Role novaRole) {
+        // Arrange
+        Long userId = 1L;
+
+        Usuario usuario = new Usuario();
+        usuario.setId(userId);
+        usuario.setNome("Teste");
+        usuario.setRole(Role.USER);
+
+        when(usuarioRepository.findById(userId)).thenReturn(Optional.of(usuario));
+        when(usuarioRepository.save(any(Usuario.class))).thenReturn(usuario);
+
+        // Act
+        Usuario atualizado = usuarioService.alterarRole(userId, novaRole);
+
+        // Assert
+        assertEquals(novaRole, atualizado.getRole());
+        verify(usuarioRepository).save(usuario);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUserNotFoundToUpdateRole() {
+    // Arrange
+    Long userId = 99L;
+    Role novaRole = Role.ADMIN;
+
+    when(usuarioRepository.findById(userId)).thenReturn(Optional.empty());
+
+    // Act + Assert
+    ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+        usuarioService.alterarRole(userId, novaRole)
+    );
+
+    assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+    assertEquals("Usuário não encontrado", exception.getReason());
+    verify(usuarioRepository, never()).save(any());
+    }
 }

--- a/stratify/src/test/java/com/quantum/stratify/web/controllers/AuthControllerTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/web/controllers/AuthControllerTest.java
@@ -1,24 +1,28 @@
 package com.quantum.stratify.web.controllers;
 
-import com.quantum.stratify.config.jwt.JwtToken;
-import com.quantum.stratify.config.jwt.JwtUserDetailsService;
-import com.quantum.stratify.entities.Usuario;
-import com.quantum.stratify.enums.Role;
-import com.quantum.stratify.web.dtos.UsuarioLoginDto;
-import jakarta.servlet.http.HttpServletRequest;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
-import java.util.Optional;
+import com.quantum.stratify.config.jwt.JwtToken;
+import com.quantum.stratify.config.jwt.JwtUserDetailsService;
+import com.quantum.stratify.entities.Usuario;
+import com.quantum.stratify.enums.Role;
+import com.quantum.stratify.web.dtos.UsuarioLoginDto;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import jakarta.servlet.http.HttpServletRequest;
 
 class AuthControllerTest {
 
@@ -43,7 +47,7 @@ class AuthControllerTest {
         Usuario usuario = new Usuario();
         usuario.setEmail("usuario@teste.com");
         usuario.setSenha("senha123");
-        usuario.setEnabled(enabled);
+        usuario.setIsEnable(enabled);
         usuario.setRequireReset(requireReset);
         usuario.setRole(Role.ADMIN);
         return usuario;

--- a/stratify/src/test/java/com/quantum/stratify/web/controllers/UserStoryControllerTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/web/controllers/UserStoryControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.quantum.stratify.services.UserStoryService;
@@ -43,13 +44,12 @@ class UserStoryControllerTest {
 
     @Test
     @DisplayName("Deve retornar 200 e lista de percentuais sem filtros")
+    @WithMockUser(username = "mockUser", roles = {"ADMIN"})
     void testPercentualSemParametros() throws Exception {
-        // Arrange juntos (testando quando não vem nenhum argumento)
         List<PercentualStatusUsuarioDTO> mockResponse = getMockResponse();
         when(userStoryStatusService.getPercentualUserStoriesPorStatus(null, null))
             .thenReturn(mockResponse);
 
-        // Act & Assert
         mockMvc.perform(get("/userStory/percentual-por-status"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0].nomeStatus").value("TO DO"))
@@ -60,14 +60,13 @@ class UserStoryControllerTest {
 
     @Test
     @DisplayName("Deve retornar percentuais com projetoId")
+    @WithMockUser(username = "mockUser", roles = {"ADMIN"})
     void testPercentualComProjetoId() throws Exception {
-        // Arrange (testnado só com projeto ID)
         Long projetoId = 1L;
         List<PercentualStatusUsuarioDTO> mockResponse = getMockResponse();
         when(userStoryStatusService.getPercentualUserStoriesPorStatus(projetoId, null))
             .thenReturn(mockResponse);
 
-        // Act & Assert
         mockMvc.perform(get("/userStory/percentual-por-status")
                 .param("projetoId", projetoId.toString()))
             .andExpect(status().isOk())
@@ -77,14 +76,13 @@ class UserStoryControllerTest {
 
     @Test
     @DisplayName("Deve retornar percentuais com usuarioId")
+    @WithMockUser(username = "mockUser", roles = {"ADMIN"})
     void testPercentualComUsuarioId() throws Exception {
-        // Arrange (testando só com usuárioid)
         Long usuarioId = 42L;
         List<PercentualStatusUsuarioDTO> mockResponse = getMockResponse();
         when(userStoryStatusService.getPercentualUserStoriesPorStatus(null, usuarioId))
             .thenReturn(mockResponse);
 
-        // Act & Assert juntos
         mockMvc.perform(get("/userStory/percentual-por-status")
                 .param("usuarioId", usuarioId.toString()))
             .andExpect(status().isOk())
@@ -94,15 +92,14 @@ class UserStoryControllerTest {
 
     @Test
     @DisplayName("Deve retornar percentuais com projetoId e usuarioId")
+    @WithMockUser(username = "mockUser", roles = {"ADMIN"})
     void testPercentualComProjetoEUsuario() throws Exception {
-        // Arrange (testando os dois cenários)
         Long projetoId = 1L;
         Long usuarioId = 42L;
         List<PercentualStatusUsuarioDTO> mockResponse = getMockResponse();
         when(userStoryStatusService.getPercentualUserStoriesPorStatus(projetoId, usuarioId))
             .thenReturn(mockResponse);
 
-        // Act & Assert juntos
         mockMvc.perform(get("/userStory/percentual-por-status")
                 .param("projetoId", projetoId.toString())
                 .param("usuarioId", usuarioId.toString()))


### PR DESCRIPTION

- Added PUT /usuarios/{idUsuario} endpoint to update a user's role, including OpenAPI documentation.
- Added GET /usuarios/filtrarprojetogestor endpoint to filter users by project and/or manager, with optional parameters.
- Updated UsuarioService to support role modification.
- Fixed unit tests in UsuarioServiceTest that were throwing NullPointerException due to improper dependency injection.
- Adjusted UsuarioService constructor to explicitly receive required dependencies.