### PR TITLE
Scrum 80 criar endpoint para resetar senha

### DIFF
--- a/stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java
+++ b/stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java
@@ -41,6 +41,18 @@ public class UsuarioService {
         }
     }
 
+    @Transactional
+    public Usuario resetarSenha(Long idUsuario, String novaSenha) {
+        Usuario usuario = buscarPorId(idUsuario);
+
+        String senhaCriptografada = passwordEncoder.encode(novaSenha);
+        usuario.setSenha(senhaCriptografada);
+        usuario.setRequireReset(false);
+
+        return usuarioRepository.save(usuario);
+    }
+
+
     public Usuario getById(Long id) {
         return usuarioRepository.findById(id)
                 .orElseThrow(() -> new jakarta.persistence.EntityNotFoundException("Usuario não encontrado com o id: " + id));

--- a/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
@@ -2,6 +2,7 @@ package com.quantum.stratify.web.controllers;
 
 import java.util.List;
 
+import com.quantum.stratify.web.dtos.ResetSenhaDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -95,5 +96,18 @@ public class UsuarioController {
         List<UsuarioDTO> usuarios = usuarioService.buscarUsuariosPorProjetoEGestor(idProjeto, idGestor);
         return ResponseEntity.ok(usuarios);
     }
-    
+
+    @PutMapping("/resetar-senha")
+    @Operation(summary = "Resetar senha de um usuário")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Senha resetada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Senha inválida"),
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
+    public ResponseEntity<String> resetarSenha(@Valid @RequestBody ResetSenhaDTO dto) {
+        usuarioService.resetarSenha(dto.getIdUsuario(), dto.getNovaSenha());
+        return ResponseEntity.ok("Senha resetada com sucesso.");
+    }
+
+
 }

--- a/stratify/src/main/java/com/quantum/stratify/web/dtos/ResetSenhaDTO.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/dtos/ResetSenhaDTO.java
@@ -1,0 +1,20 @@
+package com.quantum.stratify.web.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResetSenhaDTO {
+
+    private Long idUsuario;
+
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!]).{9,}$",
+            message = "A senha deve ter mais de 8 caracteres e conter número, letra maiúscula, minúscula e caractere especial."
+    )
+    private String novaSenha;
+}

--- a/stratify/src/test/java/com/quantum/stratify/web/controllers/AuthControllerTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/web/controllers/AuthControllerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
+import com.quantum.stratify.services.UsuarioService;
+import com.quantum.stratify.web.dtos.ResetSenhaDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -37,6 +39,12 @@ class AuthControllerTest {
 
     @Mock
     private HttpServletRequest request;
+
+    @InjectMocks
+    private UsuarioController usuarioController;
+
+    @Mock
+    private UsuarioService usuarioService;
 
     @BeforeEach
     void setup() {
@@ -114,5 +122,30 @@ class AuthControllerTest {
         ResponseEntity<?> response = authController.autenticar(dto, request);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+
+    @Test
+    void deveResetarSenhaComSucesso() {
+        ResetSenhaDTO dto = new ResetSenhaDTO();
+        dto.setIdUsuario(1L);
+        dto.setNovaSenha("Senha@123");
+
+        ResponseEntity<String> response = usuarioController.resetarSenha(dto);
+
+        verify(usuarioService).resetarSenha(1L, "Senha@123");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Senha resetada com sucesso.", response.getBody());
+    }
+
+    @Test
+    void deveRejeitarSenhaInvalida() {
+        ResetSenhaDTO dto = new ResetSenhaDTO();
+        dto.setIdUsuario(1L);
+        dto.setNovaSenha("fraca");
+
+        // Aqui simulamos manualmente a validação, já que @Valid não roda fora do contexto do Spring MVC
+        String regex = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!]).{9,}$";
+        assertFalse(dto.getNovaSenha().matches(regex));
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to reset a user's password, along with associated validation, API endpoint, and tests. The changes include adding a new service method, a DTO for password reset, a controller endpoint, and unit tests to ensure proper behavior.

### New Password Reset Functionality:

* Added a `resetarSenha` method in `UsuarioService` to reset a user's password, encrypt it, and update the user's `requireReset` flag. (`stratify/src/main/java/com/quantum/stratify/services/UsuarioService.java`)
* Created a `ResetSenhaDTO` class to validate the new password with constraints, ensuring it meets security requirements (e.g., minimum length, uppercase, lowercase, numeric, and special characters). (`stratify/src/main/java/com/quantum/stratify/web/dtos/ResetSenhaDTO.java`)

### API Endpoint:

* Added a `/resetar-senha` endpoint in `UsuarioController` to handle password reset requests, leveraging the `resetarSenha` service method and returning appropriate HTTP responses. (`stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java`)

### Unit Tests:

* Introduced unit tests in `AuthControllerTest` to verify successful password reset and rejection of invalid passwords. These tests ensure the new functionality behaves as expected. (`stratify/src/test/java/com/quantum/stratify/web/controllers/AuthControllerTest.java`)

### Supporting Changes:

* Imported necessary classes (`ResetSenhaDTO`, `UsuarioService`) in the respective files to support the new functionality. (`stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java`, `stratify/src/test/java/com/quantum/stratify/web/controllers/AuthControllerTest.java`) [[1]](diffhunk://#diff-b085dba926c5a71a35118e573d50bf34a4269baea9f30a5c7529dc0d246c83c9R5) [[2]](diffhunk://#diff-65a0954468daac74f8e5b1addb3be2477323d0fec1fb2de8f75623d4391cef31R8-R9)