### PR TITLE
SCRUM-67-feat(user-management): add admin endpoint to reset user password and send reset email

### DIFF
--- a/stratify/pom.xml
+++ b/stratify/pom.xml
@@ -135,6 +135,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
     </dependencies>
 
 	<build>

--- a/stratify/src/main/java/com/quantum/stratify/services/EmailService.java
+++ b/stratify/src/main/java/com/quantum/stratify/services/EmailService.java
@@ -1,0 +1,22 @@
+package com.quantum.stratify.services;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public EmailService(JavaMailSender mailSender) {
+    this.mailSender = mailSender;
+    }
+    public void enviarEmailSenhaResetada(String destino, String novaSenha) {
+        SimpleMailMessage mensagem = new SimpleMailMessage();
+        mensagem.setTo(destino);
+        mensagem.setSubject("Reset de senha - Stratify");
+        mensagem.setText("Sua nova senha de acesso é: " + novaSenha + "\n\nPor favor, altere após o login.");
+        mailSender.send(mensagem);
+    }
+}

--- a/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/controllers/UsuarioController.java
@@ -2,7 +2,6 @@ package com.quantum.stratify.web.controllers;
 
 import java.util.List;
 
-import com.quantum.stratify.web.dtos.ResetSenhaDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -16,12 +15,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.quantum.stratify.entities.Usuario;
+import com.quantum.stratify.enums.Role;
 import com.quantum.stratify.services.UsuarioService;
 import com.quantum.stratify.web.dtos.AlterarRoleDTO;
 import com.quantum.stratify.web.dtos.AtribuirGestor;
-import com.quantum.stratify.web.dtos.UsuarioPorRoleDTO;
-import com.quantum.stratify.enums.Role;
+import com.quantum.stratify.web.dtos.ResetSenhaAdminDTO;
+import com.quantum.stratify.web.dtos.ResetSenhaDTO;
 import com.quantum.stratify.web.dtos.UsuarioDTO;
+import com.quantum.stratify.web.dtos.UsuarioPorRoleDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -124,5 +125,15 @@ public class UsuarioController {
         return ResponseEntity.ok("Senha resetada com sucesso.");
     }
 
+    @PostMapping("/admin-reset-senha")
+    @Operation(summary = "Resetar senha de um usuário (admin)", description = "Reseta a senha do usuário, gera nova senha e envia por e-mail.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Senha resetada e enviada por e-mail"),
+        @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
+    public ResponseEntity<String> resetarSenhaAdmin(@Valid @RequestBody ResetSenhaAdminDTO dto) {
+    usuarioService.resetarSenhaAdmin(dto.getIdUsuario());
+    return ResponseEntity.ok("Senha resetada e enviada com sucesso.");
+    }
 
 }

--- a/stratify/src/main/java/com/quantum/stratify/web/dtos/ResetSenhaAdminDTO.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/dtos/ResetSenhaAdminDTO.java
@@ -1,0 +1,12 @@
+package com.quantum.stratify.web.dtos;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResetSenhaAdminDTO {
+    @NotNull
+    private Long idUsuario;
+}

--- a/stratify/src/main/resources/application.properties
+++ b/stratify/src/main/resources/application.properties
@@ -18,3 +18,14 @@ spring.datasource.hikari.idle-timeout=100
 spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 spring.liquibase.enabled=true
 spring.liquibase.default-schema=public
+
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=strategyqtb@gmail.com
+spring.mail.password=xfixdyhmlabmgtvf
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=5000
+spring.mail.properties.mail.smtp.writetimeout=5000

--- a/stratify/src/test/java/com/quantum/stratify/services/EmailServiceTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/services/EmailServiceTest.java
@@ -1,0 +1,43 @@
+package com.quantum.stratify.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+class EmailServiceTest {
+
+    private JavaMailSender mailSender;
+    private EmailService emailService;
+
+    @BeforeEach
+    void setUp() {
+        mailSender = mock(JavaMailSender.class);
+        emailService = new EmailService(mailSender); // <- injeta via construtor aqui!
+    }
+
+    @Test
+    void testEnviarEmailSenhaResetada_sucesso() {
+        // Arrange
+        String destino = "usuario@teste.com";
+        String novaSenha = "Senha123@";
+
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+
+        // Act
+        emailService.enviarEmailSenhaResetada(destino, novaSenha);
+
+        // Assert
+        verify(mailSender, times(1)).send(captor.capture());
+        SimpleMailMessage mensagemEnviada = captor.getValue();
+
+        assertEquals(destino, mensagemEnviada.getTo()[0]);
+        assertEquals("Reset de senha - Stratify", mensagemEnviada.getSubject());
+        assertTrue(mensagemEnviada.getText().contains(novaSenha));
+        assertTrue(mensagemEnviada.getText().contains("Por favor, altere após o login."));
+    }
+}


### PR DESCRIPTION
- Created POST /usuario/admin-reset-senha endpoint to allow admins to reset user passwords
- Generated random secure password and encrypted it
- Set 'require_reset' field to true after password reset
- Sent reset password via email to the user
- Added Swagger documentation for the new endpoint
- Implemented unit tests for the EmailService