### PR TITLE
SCRUM -101 -feat(FatoEficiencia): add endpoint to retrieve average ti…

### DIFF
--- a/stratify/src/main/java/com/quantum/stratify/entities/StatusHistorico.java
+++ b/stratify/src/main/java/com/quantum/stratify/entities/StatusHistorico.java
@@ -1,0 +1,23 @@
+package com.quantum.stratify.entities;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dim_status_historico")
+public class StatusHistorico {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "id_user_story", nullable = false)
+    private UserStory userStory;
+
+    @Column(name = "data_retrabalho")
+    private LocalDateTime dataRetrabalho;
+
+    @ManyToOne
+    @JoinColumn(name = "id_status", nullable = false)
+    private Status status;
+}

--- a/stratify/src/main/java/com/quantum/stratify/repositories/FatoEficienciaUserStoryRepository.java
+++ b/stratify/src/main/java/com/quantum/stratify/repositories/FatoEficienciaUserStoryRepository.java
@@ -14,35 +14,44 @@ import com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO;
 public interface FatoEficienciaUserStoryRepository extends JpaRepository<FatoEficienciaUserStory, Long> {
     FatoEficienciaUserStory findByUserStoryId(Long userStoryId);
 
-    @Query("SELECT DISTINCT new com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO( " +
-            "us.id, us.assunto, AVG(fe.tempoMedio)) " +
+    @Query("SELECT new com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO( " +
+            "us.id, us.assunto, AVG(fe.tempoMedio), count(sh)) " +
             "FROM FatoEficienciaUserStory fe " +
-            "LEFT JOIN fe.userStory us " +
+            "JOIN fe.userStory us " +
+            "LEFT JOIN StatusHistorico sh "+
+            "ON sh.userStory.id = us.id " +
             "WHERE fe.projeto.id = :projetoId " +
             "GROUP BY us.id, us.assunto ")
     List<TempoMedioPorProjetoDTO> findByProjetoId(@Param("projetoId") Long projetoId);
 
-    @Query("SELECT DISTINCT new com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO( " +
-            "us.id, us.assunto, AVG(fe.tempoMedio)) " +
+    @Query("SELECT new com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO( " +
+            "us.id, us.assunto, AVG(fe.tempoMedio), count(sh)) " +
             "FROM FatoEficienciaUserStory fe " +
-            "LEFT JOIN fe.userStory us " +
+            "JOIN fe.userStory us " +
+            "LEFT JOIN StatusHistorico sh "+
+            "ON sh.userStory.id = us.id " +
             "GROUP BY us.id, us.assunto" )
     List<TempoMedioPorProjetoDTO> getAll();
 
-    @Query("SELECT DISTINCT new com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO( " +
-            "us.id, us.assunto, AVG(fe.tempoMedio)) " +
+    @Query("SELECT new com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO( " +
+            "us.id, us.assunto, AVG(fe.tempoMedio), count(sh)) " +
             "FROM FatoEficienciaUserStory fe " +
-            "LEFT JOIN fe.userStory us " +
+            "JOIN fe.userStory us " +
+            "LEFT JOIN StatusHistorico sh "+
+            "ON sh.userStory.id = us.id " +
             "WHERE fe.projeto.id = :projetoId AND fe.usuario.id = :usuarioId " +
             "group by us.id, us.assunto")
     List<TempoMedioPorProjetoDTO> findByProjetoIdAndUsuarioId(@Param("projetoId") Long projetoId, @Param("usuarioId") Long usuarioId);
 
-    @Query("SELECT DISTINCT new com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO( " +
-            "us.id, us.assunto, AVG(fe.tempoMedio)) " +
+    @Query("SELECT new com.quantum.stratify.web.dtos.TempoMedioPorProjetoDTO( " +
+            "us.id, us.assunto, AVG(fe.tempoMedio), count(sh)) " +
             "FROM FatoEficienciaUserStory fe " +
-            "LEFT JOIN fe.userStory us " +
+            "JOIN fe.userStory us " +
+            "LEFT JOIN StatusHistorico sh "+
+            "ON sh.userStory.id = us.id " +
             "WHERE fe.usuario.id = :usuarioId " +
             "group by us.id, us.assunto")
     List<TempoMedioPorProjetoDTO> findByUsuarioId(@Param("usuarioId")Long usuarioId);
+
 
 }

--- a/stratify/src/main/java/com/quantum/stratify/repositories/StatusHistoricoRepository.java
+++ b/stratify/src/main/java/com/quantum/stratify/repositories/StatusHistoricoRepository.java
@@ -1,0 +1,16 @@
+package com.quantum.stratify.repositories;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import com.quantum.stratify.entities.StatusHistorico;
+
+import java.util.List;
+
+@Repository
+public interface StatusHistoricoRepository extends JpaRepository<StatusHistorico, Long> {
+    
+}
+

--- a/stratify/src/main/java/com/quantum/stratify/web/dtos/TempoMedioPorProjetoDTO.java
+++ b/stratify/src/main/java/com/quantum/stratify/web/dtos/TempoMedioPorProjetoDTO.java
@@ -1,7 +1,7 @@
 package com.quantum.stratify.web.dtos;
 
-public record TempoMedioPorProjetoDTO(Long idUserStory, String descricao, Long tempoMedio) {
-    public TempoMedioPorProjetoDTO(Long idUserStory, String descricao, Double tempoMedio) {
-        this(idUserStory, descricao, tempoMedio != null ? tempoMedio.longValue() : 0L);
+public record TempoMedioPorProjetoDTO(Long idUserStory, String descricao, Long tempoMedio, Long quantidadeRetrabalhos) {
+    public TempoMedioPorProjetoDTO(Long idUserStory, String descricao, Double tempoMedio, Long quantidadeRetrabalhos) {
+        this(idUserStory, descricao, tempoMedio != null ? tempoMedio.longValue() : 0L, quantidadeRetrabalhos);
     }
 }

--- a/stratify/src/test/java/com/quantum/stratify/web/controllers/FatoEficienciaUserStoryControllerTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/web/controllers/FatoEficienciaUserStoryControllerTest.java
@@ -18,6 +18,8 @@ public class FatoEficienciaUserStoryControllerTest {
     private FatoEficienciaUserStoryService service;
     private FatoEficienciaUserStoryController controller;
 
+
+
     @BeforeEach
     public void setup() {
         service = mock(FatoEficienciaUserStoryService.class);

--- a/stratify/src/test/java/com/quantum/stratify/web/controllers/FatoEficienciaUserStoryControllerTest.java
+++ b/stratify/src/test/java/com/quantum/stratify/web/controllers/FatoEficienciaUserStoryControllerTest.java
@@ -32,8 +32,8 @@ public class FatoEficienciaUserStoryControllerTest {
         Long projetoId = 1L;
         Long usuarioId = 2L;
         List<TempoMedioPorProjetoDTO> mockList = Arrays.asList(
-                new TempoMedioPorProjetoDTO(10L, "UserStory A", 5.0),
-                new TempoMedioPorProjetoDTO(11L, "UserStory B", 6.0)
+                new TempoMedioPorProjetoDTO(10L, "UserStory A", 5.0,1L),
+                new TempoMedioPorProjetoDTO(11L, "UserStory B", 6.0,1L)
         );
 
         when(service.getTempoMedioFiltrado(projetoId, usuarioId)).thenReturn(mockList);
@@ -53,7 +53,7 @@ public class FatoEficienciaUserStoryControllerTest {
     public void testGetTempoMedioPorProjetoFiltrado_semUsuario() {
         Long projetoId = 1L;
         List<TempoMedioPorProjetoDTO> mockList = Arrays.asList(
-                new TempoMedioPorProjetoDTO(20L, "UserStory C", 7.0)
+                new TempoMedioPorProjetoDTO(20L, "UserStory C", 7.0,1L)
         );
 
         when(service.getTempoMedioFiltrado(projetoId, null)).thenReturn(mockList);
@@ -74,7 +74,7 @@ public class FatoEficienciaUserStoryControllerTest {
     public void testGetTempoMedioPorProjetoFiltrado_somenteUsuario() {
         Long usuarioId = 2L;
         List<TempoMedioPorProjetoDTO> mockList = Arrays.asList(
-                new TempoMedioPorProjetoDTO(30L, "UserStory D", 8.5)
+                new TempoMedioPorProjetoDTO(30L, "UserStory D", 8.5,1L)
         );
 
         when(service.getTempoMedioFiltrado(null, usuarioId)).thenReturn(mockList);
@@ -93,7 +93,7 @@ public class FatoEficienciaUserStoryControllerTest {
     @Test
     public void testGetTempoMedioPorProjetoFiltrado_semParametros() {
         List<TempoMedioPorProjetoDTO> mockList = Arrays.asList(
-                new TempoMedioPorProjetoDTO(40L, "UserStory E", 4.2)
+                new TempoMedioPorProjetoDTO(40L, "UserStory E", 4.2,1L)
         );
 
         when(service.getTempoMedioFiltrado(null, null)).thenReturn(mockList);


### PR DESCRIPTION
This pull request introduces a new entity, `StatusHistorico`, and integrates it into the existing codebase to track the number of rework events (`quantidadeRetrabalhos`) associated with user stories. It includes updates to the database model, repository, DTOs, and queries to support this functionality.

### Entity and Repository Additions:
* Added a new entity `StatusHistorico` to represent historical status changes for user stories. This includes fields for `id`, `userStory`, `dataRetrabalho`, and `status`, with appropriate JPA annotations (`@Entity`, `@Table`, `@ManyToOne`, etc.). (`[stratify/src/main/java/com/quantum/stratify/entities/StatusHistorico.javaR1-R23](diffhunk://#diff-6ab41c5338e9716162a6ea178700f62e0d2f9f39f551350d0b8d0d39c65a8819R1-R23)`)
* Created a new repository `StatusHistoricoRepository` for managing `StatusHistorico` entities. (`[stratify/src/main/java/com/quantum/stratify/repositories/StatusHistoricoRepository.javaR1-R16](diffhunk://#diff-be5e6c875da9b954dae2744f7b2ad71243a717e1bb02c70f11aeffbd0799889dR1-R16)`)

### Query and DTO Updates:
* Updated `FatoEficienciaUserStoryRepository` queries to include a `LEFT JOIN` with `StatusHistorico` and calculate the count of rework events (`count(sh)`) for each user story. This affects methods like `findByProjetoId`, `getAll`, `findByProjetoIdAndUsuarioId`, and `findByUsuarioId`. (`[stratify/src/main/java/com/quantum/stratify/repositories/FatoEficienciaUserStoryRepository.javaL17-R56](diffhunk://#diff-a712fddcff33f79bff09a00350fa0db6ace34bd28ead6b4bfa759e54106dc833L17-R56)`)
* Modified the `TempoMedioPorProjetoDTO` to include a new field, `quantidadeRetrabalhos`, for storing the count of rework events. The constructor was updated accordingly. (`[stratify/src/main/java/com/quantum/stratify/web/dtos/TempoMedioPorProjetoDTO.javaL3-R5](diffhunk://#diff-2f551cb654849097b4afebb2e77c2d637622b4bb96b3c22875cc9c80c4dab714L3-R5)`)

### Test Code:
* Minor formatting changes in the `FatoEficienciaUserStoryControllerTest` class, with no functional impact. (`[stratify/src/test/java/com/quantum/stratify/web/controllers/FatoEficienciaUserStoryControllerTest.javaR21-R22](diffhunk://#diff-a199e29939f79982057ad2e7fe5b2362402ae5ba2228b3a4bfa828a83b1c3e5eR21-R22)`)…me and count of reworks by user and project